### PR TITLE
Utilize a ConcurrentHashMap instead of a HashMap for class instancing to resolve exception

### DIFF
--- a/api/src/main/java/com/artillexstudios/axapi/reflection/ClassUtils.java
+++ b/api/src/main/java/com/artillexstudios/axapi/reflection/ClassUtils.java
@@ -6,14 +6,15 @@ import org.slf4j.LoggerFactory;
 import sun.misc.Unsafe;
 
 import java.lang.reflect.Field;
-import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public enum ClassUtils {
     INSTANCE;
 
     private final Logger log = LoggerFactory.getLogger(ClassUtils.class);
     private final Unsafe unsafe = UnsafeUtils.INSTANCE.unsafe();
-    private final HashMap<String, Boolean> CLASS_CACHE = new HashMap<>();
+    private final Map<String, Boolean> CLASS_CACHE = new ConcurrentHashMap<>();
 
     public boolean classExists(@NotNull String className) {
         return CLASS_CACHE.computeIfAbsent(className, name -> {


### PR DESCRIPTION
Primed example:
```
[15:59:16] [Region Scheduler Thread #4/WARN]: [AxTrade] Location task for AxTrade v1.15.1 in world CraftWorld{name=world} at 968, 1134 generated an exception
java.util.ConcurrentModificationException: null
	at java.base/java.util.HashMap.computeIfAbsent(HashMap.java:1230) ~[?:?]
	at AxTrade-1.15.1-1743103570708.jar/com.artillexstudios.axtrade.libs.axapi.reflection.ClassUtils.classExists(ClassUtils.java:19) ~[AxTrade-1.15.1-1743103570708.jar:?]
	at AxTrade-1.15.1-1743103570708.jar/com.artillexstudios.axtrade.utils.ItemBuilderUtil.lambda$newBuilder$0(ItemBuilderUtil.java:26) ~[AxTrade-1.15.1-1743103570708.jar:?]
	at java.base/java.util.Optional.ifPresent(Optional.java:178) ~[?:?]
	at AxTrade-1.15.1-1743103570708.jar/com.artillexstudios.axtrade.utils.ItemBuilderUtil.newBuilder(ItemBuilderUtil.java:25) ~[AxTrade-1.15.1-1743103570708.jar:?]
	at AxTrade-1.15.1-1743103570708.jar/com.artillexstudios.axtrade.trade.GuiFrame.buildItem(GuiFrame.java:64) ~[AxTrade-1.15.1-1743103570708.jar:?]
	at AxTrade-1.15.1-1743103570708.jar/com.artillexstudios.axtrade.trade.GuiFrame.createItem(GuiFrame.java:85) ~[AxTrade-1.15.1-1743103570708.jar:?]
	at AxTrade-1.15.1-1743103570708.jar/com.artillexstudios.axtrade.trade.GuiFrame.createItem(GuiFrame.java:80) ~[AxTrade-1.15.1-1743103570708.jar:?]
	at AxTrade-1.15.1-1743103570708.jar/com.artillexstudios.axtrade.trade.GuiFrame.createItem(GuiFrame.java:76) ~[AxTrade-1.15.1-1743103570708.jar:?]
	at AxTrade-1.15.1-1743103570708.jar/com.artillexstudios.axtrade.trade.GuiFrame.createItem(GuiFrame.java:68) ~[AxTrade-1.15.1-1743103570708.jar:?]
	at AxTrade-1.15.1-1743103570708.jar/com.artillexstudios.axtrade.trade.GuiFrame.setGui(GuiFrame.java:39) ~[AxTrade-1.15.1-1743103570708.jar:?]
	at AxTrade-1.15.1-1743103570708.jar/com.artillexstudios.axtrade.trade.TradeGui.<init>(TradeGui.java:65) ~[AxTrade-1.15.1-1743103570708.jar:?]
	at AxTrade-1.15.1-1743103570708.jar/com.artillexstudios.axtrade.trade.TradePlayer.lambda$setOtherPlayer$0(TradePlayer.java:40) ~[AxTrade-1.15.1-1743103570708.jar:?]
	at AxTrade-1.15.1-1743103570708.jar/com.artillexstudios.axtrade.libs.axapi.scheduler.impl.FoliaScheduler.lambda$runAt$11(FoliaScheduler.java:84) ~[AxTrade-1.15.1-1743103570708.jar:?]
	at io.papermc.paper.threadedregions.scheduler.FoliaRegionScheduler$LocationScheduledTask.run(FoliaRegionScheduler.java:335) ~[folia-1.21.4.jar:?]
	at io.papermc.paper.threadedregions.scheduler.FoliaRegionScheduler$Scheduler.tick(FoliaRegionScheduler.java:276) ~[folia-1.21.4.jar:?]
	at io.papermc.paper.threadedregions.scheduler.FoliaRegionScheduler.tick(FoliaRegionScheduler.java:143) ~[folia-1.21.4.jar:?]
	at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1646) ~[folia-1.21.4.jar:1.21.4-DEV-bb12eee]
	at io.papermc.paper.threadedregions.TickRegions$ConcreteRegionTickHandle.tickRegion(TickRegions.java:471) ~[folia-1.21.4.jar:1.21.4-DEV-bb12eee]
	at io.papermc.paper.threadedregions.TickRegionScheduler$RegionScheduleHandle.runTick(TickRegionScheduler.java:411) ~[folia-1.21.4.jar:1.21.4-DEV-bb12eee]
	at io.papermc.paper.threadedregions.ScheduledTaskThreadPool$SchedulableTick.tick(ScheduledTaskThreadPool.java:573) ~[folia-1.21.4.jar:1.21.4-DEV-bb12eee]
	at io.papermc.paper.threadedregions.ScheduledTaskThreadPool$TickThreadRunner.doTick(ScheduledTaskThreadPool.java:1090) ~[folia-1.21.4.jar:1.21.4-DEV-bb12eee]
	at io.papermc.paper.threadedregions.ScheduledTaskThreadPool$TickThreadRunner.doRun(ScheduledTaskThreadPool.java:1137) ~[folia-1.21.4.jar:1.21.4-DEV-bb12eee]
	at io.papermc.paper.threadedregions.ScheduledTaskThreadPool$TickThreadRunner.run(ScheduledTaskThreadPool.java:1172) ~[folia-1.21.4.jar:1.21.4-DEV-bb12eee]
	at java.base/java.lang.Thread.run(Thread.java:1447) ~[?:?]