### PR TITLE
Gracefully handle missing maven credentials

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,8 +80,8 @@ allprojects {
                     name = "Artillex-Studios"
                     url = "https://repo.artillex-studios.com/releases"
                     credentials {
-                        it.username = "${maven_username}"
-                        it.password = "${maven_password}"
+                        it.username = project.findProperty("maven_username") ?: ""
+                        it.password = project.findProperty("maven_password") ?: ""
                     }
                 }
             }


### PR DESCRIPTION
Allows for local building if `maven_username` or `maven_password` are not present.